### PR TITLE
feat: add working dockerfile and compose file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,36 @@
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ __work__/
 *.log
 mqtt-pg-logger.yaml
 mqtt-pg-logger.service
-
+certs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-FROM timescaledev/timescaledb:nightly-pg16
+FROM python:3.7-alpine
 
-ENV MQTT_BROKER=127.0.0.1
-ENV POSTGRES_PASSWORD=123password
-
-RUN apk add --update --no-cache python3 py3-pip py3-virtualenv
-
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev python3-dev
-
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN apk add --no-cache gcc musl-dev
 
 RUN pip install "cython<3.0.0" wheel
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 
 RUN apk add --no-cache gcc musl-dev
 
@@ -10,11 +10,11 @@ COPY sql/table.sql /docker-entrypoint-initdb.d/00_table.sql
 COPY sql/convert.sql /docker-entrypoint-initdb.d/01_convert.sql
 COPY sql/trigger.sql /docker-entrypoint-initdb.d/02_trigger.sql
 
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-
 WORKDIR /mqtt-pg-logger
 RUN python -m pip install -r requirements.txt
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 5432
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,35 @@ Collects [MQTT](https://en.wikipedia.org/wiki/MQTT) messages and stores them in 
 - Provides the message payload as standard VARCHAR text and additionally converts the payload into a JSONB column if compatible. (See: [trigger.sql](./sql/trigger.sql) and [convert.sql](./sql/convert.sql))
 - Clean up old messages (after x days).
 
+## Docker
 
-## Startup
+### Quickstart 
+
+```docker-compose up```
+
+### Configuration 
+The docker-compose file is setup to run 
+- mqtt-pg-logger
+- ActiveMQ Artemis
+- TimescaleDB 
+
+All configuration is done via env vars in the docker-compose file, and default configuration is setup to just work out of the box. 
+
+**Ports** 
+- `8161` - Artemis Web UI 
+- `616161` - Artemis main messaging port, accepts all protocols 
+- `1883` - Artemis MQTT port
+
+### Development 
+When developing mqtt-pg-logger code make sure to rebuild the docker image after making code changes if everything is running in docker. 
+
+```
+docker-compose build mqtt-pg-logger
+docker-compose down 
+docker-compose up
+``` 
+
+## Manual
 
 ### Prerequisites
 

--- a/broker.xml
+++ b/broker.xml
@@ -1,0 +1,277 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>0.0.0.0</name>
+
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <!-- It is recommended to keep this value as 1, maximizing the number of records stored about redeliveries.
+           However if you must preserve state of individual redeliveries, you may increase this value or set it to -1 (infinite). -->
+      <max-redelivery-records>1</max-redelivery-records>
+
+      <!-- this could be ASYNCIO, MAPPED, NIO
+           ASYNCIO: Linux Libaio
+           MAPPED: mmap files
+           NIO: Plain Java Files
+       -->
+      <journal-type>ASYNCIO</journal-type>
+
+      <paging-directory>data/paging</paging-directory>
+
+      <bindings-directory>data/bindings</bindings-directory>
+
+      <journal-directory>data/journal</journal-directory>
+
+      <large-messages-directory>data/large-messages</large-messages-directory>
+
+      
+      <!-- if you want to retain your journal uncomment this following configuration.
+
+      This will allow your system to keep 7 days of your data, up to 10G. Tweak it accordingly to your use case and capacity.
+
+      it is recommended to use a separate storage unit from the journal for performance considerations.
+
+      <journal-retention-directory period="7" unit="DAYS" storage-limit="10G">data/retention</journal-retention-directory>
+
+      You can also enable retention by using the argument journal-retention on the `artemis create` command -->
+
+
+
+      <journal-datasync>true</journal-datasync>
+
+      <journal-min-files>2</journal-min-files>
+
+      <journal-pool-files>10</journal-pool-files>
+
+      <journal-device-block-size>4096</journal-device-block-size>
+
+      <journal-file-size>10M</journal-file-size>
+      
+      <!--
+       This value was determined through a calculation.
+       Your system could perform 35.71 writes per millisecond
+       on the current journal configuration.
+       That translates as a sync write every 28000 nanoseconds.
+
+       Note: If you specify 0 the system will perform writes directly to the disk.
+             We recommend this to be 0 if you are using journalType=MAPPED and journal-datasync=false.
+      -->
+      <journal-buffer-timeout>28000</journal-buffer-timeout>
+
+
+      <!--
+        When using ASYNCIO, this will determine the writing queue depth for libaio.
+       -->
+      <journal-max-io>4096</journal-max-io>
+      <!--
+        You can verify the network health of a particular NIC by specifying the <network-check-NIC> element.
+         <network-check-NIC>theNicName</network-check-NIC>
+        -->
+
+      <!--
+        Use this to use an HTTP server to validate the network
+         <network-check-URL-list>http://www.apache.org</network-check-URL-list> -->
+
+      <!-- <network-check-period>10000</network-check-period> -->
+      <!-- <network-check-timeout>1000</network-check-timeout> -->
+
+      <!-- this is a comma separated list, no spaces, just DNS or IPs
+           it should accept IPV6
+
+           Warning: Make sure you understand your network topology as this is meant to validate if your network is valid.
+                    Using IPs that could eventually disappear or be partially visible may defeat the purpose.
+                    You can use a list of multiple IPs, and if any successful ping will make the server OK to continue running -->
+      <!-- <network-check-list>10.0.0.1</network-check-list> -->
+
+      <!-- use this to customize the ping used for ipv4 addresses -->
+      <!-- <network-check-ping-command>ping -c 1 -t %d %s</network-check-ping-command> -->
+
+      <!-- use this to customize the ping used for ipv6 addresses -->
+      <!-- <network-check-ping6-command>ping6 -c 1 %2$s</network-check-ping6-command> -->
+
+
+
+
+      <!-- how often we are looking for how many bytes are being used on the disk in ms -->
+      <disk-scan-period>5000</disk-scan-period>
+
+      <!-- once the disk hits this limit the system will block, or close the connection in certain protocols
+           that won't support flow control. -->
+      <max-disk-usage>90</max-disk-usage>
+
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      
+      <page-sync-timeout>1172000</page-sync-timeout>
+
+
+      <!-- the system will enter into page mode once you hit this limit. This is an estimate in bytes of how much the messages are using in memory
+
+      The system will use half of the available memory (-Xmx) by default for the global-max-size.
+      You may specify a different value here if you need to customize it to your needs.
+
+      <global-max-size>100Mb</global-max-size> -->
+
+      <!-- the maximum number of messages accepted before entering full address mode.
+           if global-max-size is specified the full address mode will be specified by whatever hits it first. -->
+      <global-max-messages>-1</global-max-messages>
+
+      <acceptors>
+
+         <!-- useEpoll means: it will use Netty epoll if you are on a system (Linux) that supports it -->
+         <!-- amqpCredits: The number of credits sent to AMQP producers -->
+         <!-- amqpLowCredits: The server will send the # credits specified at amqpCredits at this low mark -->
+         <!-- amqpDuplicateDetection: If you are not using duplicate detection, set this to false
+                                      as duplicate detection requires applicationProperties to be parsed on the server. -->
+         <!-- amqpMinLargeMessageSize: Determines how many bytes are considered large, so we start using files to hold their data.
+                                       default: 102400, -1 would mean to disable large message control -->
+
+         <!-- Note: If an acceptor needs to be compatible with HornetQ and/or Artemis 1.x clients add
+                    "anycastPrefix=jms.queue.;multicastPrefix=jms.topic." to the acceptor url.
+                    See https://issues.apache.org/jira/browse/ARTEMIS-1644 for more information. -->
+
+
+         <!-- Acceptor for every supported protocol -->
+         <acceptor name="artemis">tcp://0.0.0.0:61616?sslEnabled=true;keyStorePath=/etc/ssl/certs/server-keystore.jks;keyStorePassword=securepass;tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;amqpMinLargeMessageSize=102400;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpDuplicateDetection=true;supportAdvisory=false;suppressInternalManagementObjects=false</acceptor>
+
+         <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
+         <acceptor name="amqp">tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpMinLargeMessageSize=102400;amqpDuplicateDetection=true</acceptor>
+
+         <!-- STOMP Acceptor. -->
+         <acceptor name="stomp">tcp://0.0.0.0:61613?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true</acceptor>
+
+         <!-- HornetQ Compatibility Acceptor.  Enables HornetQ Core and STOMP for legacy HornetQ clients. -->
+         <acceptor name="hornetq">tcp://0.0.0.0:5445?anycastPrefix=jms.queue.;multicastPrefix=jms.topic.;protocols=HORNETQ,STOMP;useEpoll=true</acceptor>
+
+         <!-- MQTT Acceptor -->
+         <acceptor name="mqtt">tcp://0.0.0.0:1883?sslEnabled=true;keyStorePath=/etc/ssl/certs/server-keystore.jks;keyStorePassword=securepass;tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true</acceptor>
+
+      </acceptors>
+
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="amq"/>
+            <permission type="deleteNonDurableQueue" roles="amq"/>
+            <permission type="createDurableQueue" roles="amq"/>
+            <permission type="deleteDurableQueue" roles="amq"/>
+            <permission type="createAddress" roles="amq"/>
+            <permission type="deleteAddress" roles="amq"/>
+            <permission type="consume" roles="amq"/>
+            <permission type="browse" roles="amq"/>
+            <permission type="send" roles="amq"/>
+            <!-- we need this otherwise ./artemis data imp wouldn't work -->
+            <permission type="manage" roles="amq"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!-- if you define auto-create on certain queues, management has to be auto-create -->
+         <address-setting match="activemq.management#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+            <auto-delete-queues>false</auto-delete-queues>
+            <auto-delete-addresses>false</auto-delete-addresses>
+
+            <!-- The size of each page file -->
+            <page-size-bytes>10M</page-size-bytes>
+
+            <!-- When we start applying the address-full-policy, e.g paging -->
+            <!-- Both are disabled by default, which means we will use the global-max-size/global-max-messages  -->
+            <max-size-bytes>-1</max-size-bytes>
+            <max-size-messages>-1</max-size-messages>
+
+            <!-- When we read from paging into queues (memory) -->
+
+            <max-read-page-messages>-1</max-read-page-messages>
+            <max-read-page-bytes>20M</max-read-page-bytes>
+
+            <!-- Limit on paging capacity before starting to throw errors -->
+
+            <page-limit-bytes>-1</page-limit-bytes>
+            <page-limit-messages>-1</page-limit-messages>
+          </address-setting>
+      </address-settings>
+
+      <addresses>
+         <address name="DLQ">
+            <anycast>
+               <queue name="DLQ" />
+            </anycast>
+         </address>
+         <address name="ExpiryQueue">
+            <anycast>
+               <queue name="ExpiryQueue" />
+            </anycast>
+         </address>
+
+      </addresses>
+
+
+      <!-- Uncomment the following if you want to use the Standard LoggingActiveMQServerPlugin pluging to log in events
+      <broker-plugins>
+         <broker-plugin class-name="org.apache.activemq.artemis.core.server.plugin.impl.LoggingActiveMQServerPlugin">
+            <property key="LOG_ALL_EVENTS" value="true"/>
+            <property key="LOG_CONNECTION_EVENTS" value="true"/>
+            <property key="LOG_SESSION_EVENTS" value="true"/>
+            <property key="LOG_CONSUMER_EVENTS" value="true"/>
+            <property key="LOG_DELIVERING_EVENTS" value="true"/>
+            <property key="LOG_SENDING_EVENTS" value="true"/>
+            <property key="LOG_INTERNAL_EVENTS" value="true"/>
+         </broker-plugin>
+      </broker-plugins>
+      -->
+
+   </core>
+</configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     ports:
       - 8161:8161 # Web Console
       - 61616:61616 # Main Messaging Port
-    # volumes:
-      # - artemis-config:/var/lib/artemis-instance
+      - 1883:1883 # MQTT Port
+    volumes:
+      - ./certs:/etc/ssl/certs
+      - ./broker.xml:/var/lib/artemis-instance/etc-override/broker.xml
     restart: unless-stopped
 
   mqtt-pg-logger:
@@ -23,6 +25,9 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DATABASE=postgres
+      - CA_CERT_PATH=/etc/ssl/certs/server-ca.crt
+    volumes:
+      - ./certs:/etc/ssl/certs
     restart: unless-stopped
 
   timescaledb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  artemis:
+    image: apache/activemq-artemis:latest-alpine
+    ports:
+      - 8161:8161 # Web Console
+      - 61616:61616 # Main Messaging Port
+    # volumes:
+      # - artemis-config:/var/lib/artemis-instance
+    restart: unless-stopped
+
+  mqtt-pg-logger:
+    build: .
+    depends_on:
+      - artemis
+      - timescaledb
+    environment:
+      - MQTT_HOST=artemis
+      - MQTT_PORT=61616
+      - MQTT_USER=artemis
+      - MQTT_PASSWORD=artemis
+      - POSTGRES_HOST=timescaledb
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DATABASE=postgres
+    restart: unless-stopped
+
+  timescaledb:
+    image: timescale/timescaledb:latest-pg16
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+    restart: unless-stopped
+
+volumes:
+  artemis-config:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,14 @@
 cd /mqtt-pg-logger
 cp mqtt-pg-logger.yaml.sample mqtt-pg-logger.yaml
 chmod 600 mqtt-pg-logger.yaml
-sed -i -e "s/<your[_ ]broker>/${MQTT_HOST}/g" \
-    -e "s/<your[_ ]database[_ ]password>/${POSTGRES_PASSWORD}/g" \
-    -e "s/<your[_ ]database[_ ]user>/${POSTGRES_USER}/g" \
-    -e "s/<your[_ ]database[_ ]name>/${POSTGRES_DATABASE}/g" \
-    -e "s/<your[_ ]database[_ ]host>/${POSTGRES_HOST}/g" \
-    -e "s/<your_mqtt_user>/${MQTT_USER}/g" \
-    -e "s/<your_mqtt_password>/${MQTT_PASSWORD}/g" \
+sed -i -e "s#<your[_ ]broker>#${MQTT_HOST}#g" \
+    -e "s#<your[_ ]database[_ ]password>#${POSTGRES_PASSWORD}#g" \
+    -e "s#<your[_ ]database[_ ]user>#${POSTGRES_USER}#g" \
+    -e "s#<your[_ ]database[_ ]name>#${POSTGRES_DATABASE}#g" \
+    -e "s#<your[_ ]database[_ ]host>#${POSTGRES_HOST}#g" \
+    -e "s#<your_mqtt_user>#${MQTT_USER}#g" \
+    -e "s#<your_mqtt_password>#${MQTT_PASSWORD}#g" \
+    -e "s#<path_to_your_ca_cert>#${CA_CERT_PATH}#g" \
     mqtt-pg-logger.yaml
 
 cat mqtt-pg-logger.yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,22 +1,19 @@
 #!/bin/sh
 
-[ -n "${MQTT_BROKER}" ] || exit 1
-
-USER=${POSTGRES_USER:-postgres}
-NAME=${POSTGRES_DB:-$USER}
+[ -n "${MQTT_HOST}" ] || exit 1
 
 cd /mqtt-pg-logger
 cp mqtt-pg-logger.yaml.sample mqtt-pg-logger.yaml
 chmod 600 mqtt-pg-logger.yaml
-sed -i -e "s/<your[_ ]broker>/${MQTT_BROKER}/g" \
+sed -i -e "s/<your[_ ]broker>/${MQTT_HOST}/g" \
     -e "s/<your[_ ]database[_ ]password>/${POSTGRES_PASSWORD}/g" \
-    -e "s/<your[_ ]database[_ ]user>/${USER}/g" \
-    -e "s/<your[_ ]database[_ ]name>/${NAME}/g" \
+    -e "s/<your[_ ]database[_ ]user>/${POSTGRES_USER}/g" \
+    -e "s/<your[_ ]database[_ ]name>/${POSTGRES_DATABASE}/g" \
+    -e "s/<your[_ ]database[_ ]host>/${POSTGRES_HOST}/g" \
+    -e "s/<your_mqtt_user>/${MQTT_USER}/g" \
+    -e "s/<your_mqtt_password>/${MQTT_PASSWORD}/g" \
     mqtt-pg-logger.yaml
 
-docker-entrypoint.sh postgres &
+cat mqtt-pg-logger.yaml
 
-until runuser -l postgres -c 'pg_isready -q'; do sleep 1; done
-
-start-stop-daemon -S -x /mqtt-pg-logger/mqtt-pg-logger.sh -- --config-file /mqtt-pg-logger/mqtt-pg-logger.yaml
-
+sh ./mqtt-pg-logger.sh --print-logs --config-file ./mqtt-pg-logger.yaml

--- a/mqtt-pg-logger.sh
+++ b/mqtt-pg-logger.sh
@@ -8,20 +8,6 @@ SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 SCRIPT_NAME=$(basename $0)
 cd "$SCRIPT_DIR"
 
-VENV_ACTIVATE="./venv/bin/activate"
-if [ ! -f "$VENV_ACTIVATE" ] ; then
-	echo -e "$SCRIPT_NAME\nerror: venv environment doesn't exist!"
-	exit 1
-fi
-
-source "$VENV_ACTIVATE"
-RC=$?
-if [ $RC -ne 0 ] ; then
-	echo -e "$SCRIPT_NAME\nerror: activating environment failed!"
-	exit 1
-fi
-
-
 export PYTHONPATH="$SCRIPT_DIR"
 
 python ./src/mqtt_pg_logger.py $@

--- a/mqtt-pg-logger.yaml.sample
+++ b/mqtt-pg-logger.yaml.sample
@@ -9,6 +9,8 @@ mqtt:
     port:                       1883
     user:                       "<your_mqtt_user>"
     password:                   "<your_mqtt_password>"
+    ssl_ca_certs:               "<path_to_your_ca_cert>"
+    ssl_insecure:               True
     protocol:                   4  # 3==MQTTv31 (default), 4==MQTTv311, 5==default/MQTTv5,
     # filter_message_id_0:      True
     subscriptions:              ["smarthome/#", "smarthome2/#"]  # topics

--- a/mqtt-pg-logger.yaml.sample
+++ b/mqtt-pg-logger.yaml.sample
@@ -7,13 +7,15 @@ mqtt:
     client_id:                  "mqtt-pg-logger-1234"
     host:                       "<your_broker>"
     port:                       1883
+    user:                       "<your_mqtt_user>"
+    password:                   "<your_mqtt_password>"
     protocol:                   4  # 3==MQTTv31 (default), 4==MQTTv311, 5==default/MQTTv5,
     # filter_message_id_0:      True
     subscriptions:              ["smarthome/#", "smarthome2/#"]  # topics
     skip_subscription_regexes:  []  # regex for topics
 
 database:
-    host:                       "localhost"
+    host:                       "<your database host>"
     port:                       5432
     user:                       "<your database user>"
     password:                   "<your database password>"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 
 flake8
 testing.postgresql == 1.3.0
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ attrs == 22.2.0
 click == 8.1.3
 jsonschema == 4.17.3
 paho-mqtt == 1.6.1
-psycopg == 3.1.7
+psycopg[binary] == 3.1.7
 tzlocal == 4.2
+pyyaml
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs == 22.2.0
 click == 8.1.3
 jsonschema == 4.17.3
 paho-mqtt == 1.6.1
-psycopg[binary] == 3.1.7
+psycopg[binary] == 3.2.3
 tzlocal == 4.2
 pyyaml
 wheel


### PR DESCRIPTION
- Change the Dockerfile to use the python:3.12-alpine image, also removed virtualenv stuff from container
- Added docker-compose file that connects with ActiveMQ Artemis and TimescaleDB
- Updated configuration yaml to take mqtt username and password 
- Add pyyaml to requirements (idk why it wasn't there)
- Changed psycopg to psycopg[binary] in requirements (this was needed to make it work in Docker)
- Remove virtualenv logic from `mqtt-pg-logger.sh`, but actually I'll leave that alone and put in the logic to start the python process in `entrypoint.sh` itself 